### PR TITLE
escape `<` and `>` symbols

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -76,6 +76,11 @@ function getDestinationDir(vFile) {
  * @return {object}
  */
 function createMermaidDiv(contents) {
+  // `<` and `>` characters are used in some mermaid graphs, but rehype will
+  // break them to avoid HTML injection. We have to escape them, thankfully
+  // mermaid recognizes the escaped versions.
+  contents = contents.replace(/[<]/g, "&lt;").replace(/[>]/g, "&gt;");
+
   return {
     type: 'html',
     value: `<div class="mermaid">


### PR DESCRIPTION
This is required for https://github.com/dendronhq/dendron/issues/2630

Once this is merged and published, I'll bump the version in Dendron to fix the issue fully.