### PR TITLE
chore: removing non-browser compatible dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "url": "git@github.com:temando/remark-mermaid.git"
   },
   "dependencies": {
-    "fs-extra": "^4.0.1",
-    "unist-util-visit": "^1.1.3",
-    "which": "^1.3.0"
+    "unist-util-visit": "^1.1.3"
   },
   "devDependencies": {
     "changelog-verify": "^1.0.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra');
+// const fs = require('fs-extra');
 const visit = require('unist-util-visit');
 const utils = require('./utils');
 
@@ -66,16 +66,16 @@ function replaceLinkWithEmbedded(node, index, parent, vFile) {
     return node;
   }
 
-  try {
-    const value = fs.readFileSync(`${vFile.dirname}/${url}`, { encoding: 'utf-8' });
+  // try {
+  //   const value = fs.readFileSync(`${vFile.dirname}/${url}`, { encoding: 'utf-8' });
 
-    newNode = createMermaidDiv(value);
-    parent.children.splice(index, 1, newNode);
-    vFile.info('mermaid link replaced with div', position, PLUGIN_NAME);
-  } catch (error) {
-    vFile.message(error, position, PLUGIN_NAME);
-    return node;
-  }
+  //   newNode = createMermaidDiv(value);
+  //   parent.children.splice(index, 1, newNode);
+  //   vFile.info('mermaid link replaced with div', position, PLUGIN_NAME);
+  // } catch (error) {
+  //   vFile.message(error, position, PLUGIN_NAME);
+  //   return node;
+  // }
 
   return node;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,8 @@
 const crypto = require('crypto');
-const fs = require('fs-extra');
-const path = require('path');
-const which = require('which');
-const execSync = require('child_process').execSync;
+// const fs = require('fs-extra');
+// const path = require('path');
+// const which = require('which');
+// const execSync = require('child_process').execSync;
 
 const PLUGIN_NAME = 'remark-mermaid';
 
@@ -16,19 +16,19 @@ const PLUGIN_NAME = 'remark-mermaid';
  */
 function render(source, destination) {
   const unique = crypto.createHmac('sha1', PLUGIN_NAME).update(source).digest('hex');
-  const mmdcExecutable = which.sync('mmdc');
-  const mmdPath = path.join(destination, `${unique}.mmd`);
+  // const mmdcExecutable = which.sync('mmdc');
+  // const mmdPath = path.join(destination, `${unique}.mmd`);
   const svgFilename = `${unique}.svg`;
-  const svgPath = path.join(destination, svgFilename);
+  // const svgPath = path.join(destination, svgFilename);
 
-  // Write temporary file
-  fs.outputFileSync(mmdPath, source);
+  // // Write temporary file
+  // fs.outputFileSync(mmdPath, source);
 
-  // Invoke mermaid.cli
-  execSync(`${mmdcExecutable} -i ${mmdPath} -o ${svgPath} -b transparent`);
+  // // Invoke mermaid.cli
+  // execSync(`${mmdcExecutable} -i ${mmdPath} -o ${svgPath} -b transparent`);
 
-  // Clean up temporary file
-  fs.removeSync(mmdPath);
+  // // Clean up temporary file
+  // fs.removeSync(mmdPath);
 
   return `./${svgFilename}`;
 }
@@ -43,12 +43,12 @@ function render(source, destination) {
  */
 function renderFromFile(inputFile, destination) {
   const unique = crypto.createHmac('sha1', PLUGIN_NAME).update(inputFile).digest('hex');
-  const mmdcExecutable = which.sync('mmdc');
+  // const mmdcExecutable = which.sync('mmdc');
   const svgFilename = `${unique}.svg`;
-  const svgPath = path.join(destination, svgFilename);
+  // const svgPath = path.join(destination, svgFilename);
 
   // Invoke mermaid.cli
-  execSync(`${mmdcExecutable} -i ${inputFile} -o ${svgPath} -b transparent`);
+  // execSync(`${mmdcExecutable} -i ${inputFile} -o ${svgPath} -b transparent`);
 
   return `./${svgFilename}`;
 }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+// const fs = require('fs');
 const path = require('path');
 const toVFile = require('to-vfile');
 const { render, renderFromFile, getDestinationDir } = require('../src/utils');
@@ -17,18 +17,18 @@ function addMetadata(vFile, destinationFilePath) {
 }
 
 describe('remark-mermaid utils', () => {
-  it('renders a mermaid graph', () => {
-    const mermaidExample = fs.readFileSync(`${fixturesDir}/example.mmd`, 'utf8');
-    let renderedGraphFile;
+  // it('renders a mermaid graph', () => {
+  //   const mermaidExample = fs.readFileSync(`${fixturesDir}/example.mmd`, 'utf8');
+  //   let renderedGraphFile;
 
-    try {
-      renderedGraphFile = render(mermaidExample, runtimeDir);
-    } catch (err) {
-      console.error(err.message);
-    }
+  //   try {
+  //     renderedGraphFile = render(mermaidExample, runtimeDir);
+  //   } catch (err) {
+  //     console.error(err.message);
+  //   }
 
-    expect(renderedGraphFile).not.toBeUndefined();
-  });
+  //   expect(renderedGraphFile).not.toBeUndefined();
+  // });
 
   it('renders from a file a mermaid graph', () => {
     let renderedGraphFile;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1090,14 +1090,6 @@ form-data@~2.3.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-fs-extra@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1208,7 +1200,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1935,12 +1927,6 @@ json-stringify-safe@~5.0.1:
 json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -3194,10 +3180,6 @@ unist-util-visit@^1.1.0, unist-util-visit@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.1.3.tgz#ec268e731b9d277a79a5b5aa0643990e405d600b"
 
-universalify@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
-
 upath@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-0.2.0.tgz#bdbad0f2c60afea165f8127dbb1b5bdee500ad81"
@@ -3287,7 +3269,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.12, which@^1.2.9, which@^1.3.0:
+which@^1.2.12, which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:


### PR DESCRIPTION
Removes fs dependencies from remark-mermaid to make it browser compatible. 

This should be fine for Dendron's usage, since we only use 'simple' mode which doesn't require any fs usage.